### PR TITLE
Added items method to categories.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,8 @@ API Changes
 
 
 Enhancements
+   * Added `items` method to `Categories`, giving greater interface parity with
+     `dict`.
 
 
 Fixes

--- a/src/datreant/metadata.py
+++ b/src/datreant/metadata.py
@@ -513,6 +513,19 @@ class Categories(Metadata):
         with self._read:
             return self._statefile._state.values()
 
+    def items(self):
+        """Get category (key, value) tuples.
+
+        Returns
+        -------
+        items : list
+            (key, value) tuples; corresponds to `dict.items`.
+        """
+        with self._read:
+            return self._statefile._state.items()
+
+
+
 
 class AggMetadata(object):
 

--- a/src/datreant/metadata.py
+++ b/src/datreant/metadata.py
@@ -525,8 +525,6 @@ class Categories(Metadata):
             return self._statefile._state.items()
 
 
-
-
 class AggMetadata(object):
 
     def __init__(self, collection):

--- a/src/datreant/tests/test_treants.py
+++ b/src/datreant/tests/test_treants.py
@@ -490,6 +490,24 @@ class TestTreant(TestTree):
             with tmpdir.as_cwd():
                 dtr.Treant('sprout', categories=treant.categories)
 
+        def test_getters(self, treant, tmpdir):
+            with tmpdir.as_cwd():
+                treant.categories = {'happy': True,
+                                     'fulfilled': False,
+                                     'number': 27}
+
+                assert set(treant.categories.keys()) == {'happy',
+                                                         'fulfilled',
+                                                         'number'}
+
+                assert set(treant.categories.values()) == {True,
+                                                           False,
+                                                           27}
+
+                assert set(treant.categories.items()) == {('happy', True),
+                                                          ('fulfilled', False),
+                                                          ('number', 27)}
+
 
 class TestReadOnly:
     """Test Treant functionality when read-only"""


### PR DESCRIPTION
Fixes #143 

Added an `items` method to `Categories`. This gives it greater interface parity with `dict`.