### PR TITLE
WIP: Merge `datreant.cli` into `datreant`, along with some improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,11 @@ setup(
     package_dir={'': 'src'},
     scripts=[],
     entry_points={'console_scripts':
-                  ['datreant_07to1=datreant.scripts.datreant_07to1:main']},
+                  ['datreant_07to1=datreant.scripts.datreant_07to1:main',
+                   'dtr=datreant.cli:cli']},
     license='BSD',
     long_description=open('README.rst').read(),
     tests_require=['numpy', 'pytest>=2.10', 'mock'],
     install_requires=[
         'asciitree', 'scandir', 'fuzzywuzzy',
-        'python-Levenshtein', 'pyparsing'])
+        'python-Levenshtein', 'pyparsing', 'click'])

--- a/src/datreant/cli.py
+++ b/src/datreant/cli.py
@@ -193,8 +193,8 @@ def discover(dirs, relpath, tags, categories, json_):
 
     res = _get(dirs, tags, categories)
 
-    if json:
-        res = dirs.map(print_treant, detail=True)
+    if json_:
+        res = res.map(print_treant, detail=True)
         click.echo(json.dumps(res, indent=4))
     else:
         paths = res.relpaths if relpath else res.abspaths

--- a/src/datreant/cli.py
+++ b/src/datreant/cli.py
@@ -1,0 +1,139 @@
+"""
+datreant.cli
+"""
+from __future__ import print_function
+
+import click
+import datreant as dtr
+
+
+class OptionEatAll(click.Option):
+    # from
+    # https://stackoverflow.com/a/48394004/2207958
+
+    def __init__(self, *args, **kwargs):
+        self.save_other_options = kwargs.pop("save_other_options", True)
+        nargs = kwargs.pop("nargs", -1)
+        assert nargs == -1, "nargs, if set, must be -1 not {}".format(nargs)
+        super(OptionEatAll, self).__init__(*args, **kwargs)
+        self._previous_parser_process = None
+        self._eat_all_parser = None
+
+    def add_to_parser(self, parser, ctx):
+        def parser_process(value, state):
+            # method to hook to the parser.process
+            done = False
+            value = [value]
+            if self.save_other_options:
+                # grab everything up to the next option
+                while state.rargs and not done:
+                    for prefix in self._eat_all_parser.prefixes:
+                        if state.rargs[0].startswith(prefix):
+                            done = True
+                    if not done:
+                        value.append(state.rargs.pop(0))
+            else:
+                # grab everything remaining
+                value += state.rargs
+                state.rargs[:] = []
+            value = tuple(value)
+
+            # call the actual process
+            self._previous_parser_process(value, state)
+
+        retval = super(OptionEatAll, self).add_to_parser(parser, ctx)
+        for name in self.opts:
+            our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
+            if our_parser:
+                self._eat_all_parser = our_parser
+                self._previous_parser_process = our_parser.process
+                our_parser.process = parser_process
+                break
+        return retval
+
+
+@click.group()
+@click.version_option()
+def cli():
+    """CLI interface for datreant filesystem databases"""
+    pass
+
+
+@cli.command()
+@click.argument("folder", default=".")
+def init(folder):
+    """turn folder into a treant"""
+    dtr.Treant(folder)
+
+
+def print_treant(treant, verbose=False):
+    """print treant with more human readable information"""
+    print("abspath: ", treant)
+    if verbose:
+        print("tags: ", treant.tags)
+        print("categories: ", treant.categories)
+
+
+@cli.command()
+@click.argument("folder", default=".")
+def show(folder):
+    """show content of treant"""
+    tree = dtr.Tree(folder)
+    if tree[".datreant"].exists:
+        treant = dtr.Treant(folder)
+        print_treant(treant, verbose=True)
+    else:
+        print("not a treant")
+
+
+@cli.command()
+@click.option("--tags", cls=OptionEatAll, help="list of tags")
+@click.option(
+    "--categories",
+    cls=OptionEatAll,
+    help="list of categories as key-value pairs separated by a double point ':'",
+)
+@click.argument("folder", default=".")
+def update(tags, categories, folder):
+    """update tags and categories of treant"""
+    treant = dtr.Treant(folder)
+    if tags is not None:
+        treant.tags = set(tags)
+    if categories is not None:
+        for key, value in (c.split(":") for c in categories):
+            treant.categories[key] = value
+
+
+@cli.command()
+@click.argument("folder", default=".")
+@click.option("--tags", cls=OptionEatAll, help="list of tags or search string")
+@click.option(
+    "--categories",
+    cls=OptionEatAll,
+    help="list of categories as key-value pairs separated by a double point ':'",
+)
+@click.option("--verbose", is_flag=True, help="list tags and categories as well")
+def search(tags, folder, categories, verbose):
+    """search folder for treants and list them"""
+    bundle = dtr.discover(folder)
+
+    if tags is not None:
+        if len(tags) != 1:
+            tags = set(tags)
+        bundle = bundle[bundle.tags[tags]]
+
+    if categories is not None:
+        categories = {k: v for k, v in (c.split(":") for c in categories)}
+        groupby = bundle.categories.groupby(list(categories.keys()))
+        bundle = groupby[set(categories.values())]
+
+    for treant in bundle:
+        if verbose:
+            print_treant(treant, verbose=True)
+        else:
+            print(treant.abspath)
+
+
+# for easier debugging
+if __name__ == "__main__":
+    cli()

--- a/src/datreant/cli.py
+++ b/src/datreant/cli.py
@@ -215,7 +215,7 @@ def _get(bundle, tags, categories):
 
 @cli.command()
 @click.argument("dirs", nargs=-1)
-@click.option("--relpath/--abspath", 'relpath', default=True,
+@click.option("--relpath/--abspath", "-r/-a", 'relpath', default=True,
               help="return relative or absolute paths")
 @click.option("--json", '-j', 'json_', is_flag=True,
               help="return results in JSON format")
@@ -242,7 +242,8 @@ def get(dirs, relpath, json_, tags, categories):
         if res:
             click.echo(json.dumps(res, indent=4))
     else:
-        click.echo("\n".join(res.abspaths))
+        paths = res.relpaths if relpath else res.abspaths
+        click.echo("\n".join(paths))
 
 
 @cli.command()

--- a/src/datreant/cli.py
+++ b/src/datreant/cli.py
@@ -122,7 +122,7 @@ def _set(treant, tags, categories):
     cls=OptionEatAll,
     help="list of categories as key-value pairs separated by a colon ':'",
 )
-def init(dirs):
+def init(dirs, tags=None, categories=None):
     """Make treants from dirs, optionally setting tags/categories"""
     dirs = _handle_stdin(dirs)
 
@@ -314,7 +314,7 @@ def categories(dirs, all_, json_, get):
 
 
 def _parse_categories(catstrings):
-    return {key: json.loads(value) for key, value in
+    return {key: value for key, value in
             (c.split(":") for c in catstrings)}
 
 

--- a/src/datreant/cli.py
+++ b/src/datreant/cli.py
@@ -314,7 +314,17 @@ def categories(dirs, all_, json_, get):
 
 
 def _parse_categories(catstrings):
-    return {key: value for key, value in
+    def value_convert(val):
+        # from least to most permissive:
+        # int -> float -> string
+        try:
+            return int(val)
+        except ValueError:
+            try:
+                return float(val)
+            except ValueError:
+                return val
+    return {key: value_convert(value) for key, value in
             (c.split(":") for c in catstrings)}
 
 

--- a/src/datreant/cli.py
+++ b/src/datreant/cli.py
@@ -53,6 +53,7 @@ class OptionEatAll(click.Option):
                 break
         return retval
 
+
 class AliasedGroup(click.Group):
 
     def list_commands(self, ctx):
@@ -69,6 +70,7 @@ class AliasedGroup(click.Group):
                        'clear',
                        'help']
         return subcommands
+
 
 @click.command(cls=AliasedGroup)
 @click.version_option()
@@ -89,8 +91,9 @@ def help(ctx):
     """Show the CLI help contents"""
     click.echo(ctx.parent.get_help())
 
+
 def _handle_stdin(dirs):
-    if (len(dirs) == 1) and (dirs[0] == '-') :
+    if (len(dirs) == 1) and (dirs[0] == '-'):
         try:
             with click.get_text_stream('stdin') as stdin:
                 stdin_text = stdin.read()
@@ -101,7 +104,8 @@ def _handle_stdin(dirs):
         dirs = ('.',)
 
     return dirs
-        
+
+
 def _set(treant, tags, categories):
     if tags is not None:
         treant.tags = set(tags)
@@ -151,7 +155,7 @@ def show(dirs):
     # get all existing Treants among dirs
     dirs = dtr.Bundle(dirs, ignore=True)
     res = dirs.map(print_treant, detail=True)
-    
+
     if res:
         click.echo(json.dumps(res, indent=4))
 
@@ -170,7 +174,8 @@ def draw(dirs):
 
 @cli.command()
 @click.argument("dirs", nargs=-1)
-@click.option("--relpath/--abspath", "-r/-a", 'relpath', default=True, help="return relative or absolute paths")
+@click.option("--relpath/--abspath", "-r/-a", 'relpath', default=True,
+              help="return relative or absolute paths")
 @click.option("--tags", '-t', cls=OptionEatAll, help="list of tags")
 @click.option(
     "--categories",
@@ -210,10 +215,12 @@ def _get(bundle, tags, categories):
 
 @cli.command()
 @click.argument("dirs", nargs=-1)
-@click.option("--relpath/--abspath", 'relpath', default=True, help="return relative or absolute paths")
+@click.option("--relpath/--abspath", 'relpath', default=True,
+              help="return relative or absolute paths")
 @click.option("--json", '-j', 'json_', is_flag=True,
               help="return results in JSON format")
-@click.option("--tags", '-t', cls=OptionEatAll, help="list of tags or search string")
+@click.option("--tags", '-t', cls=OptionEatAll,
+              help="list of tags or search string")
 @click.option(
     "--categories",
     '-c',
@@ -238,7 +245,6 @@ def get(dirs, relpath, json_, tags, categories):
         click.echo("\n".join(res.abspaths))
 
 
-
 @cli.command()
 @click.argument("dirs", metavar='<dir(s)>', nargs=-1)
 @click.option("--all/--any", 'all_', default=True,
@@ -246,7 +252,8 @@ def get(dirs, relpath, json_, tags, categories):
 @click.option("--json", '-j', 'json_', is_flag=True,
               help="return results in JSON format")
 @click.option("--has", cls=OptionEatAll,
-              help="list of tags; returns true for presence, false for absence")
+              help=("list of tags; for each returns true if present,"
+                    " false if absent"))
 def tags(dirs, all_, json_, has):
     """Show treant tags"""
     dirs = _handle_stdin(dirs)
@@ -272,8 +279,10 @@ def tags(dirs, all_, json_, has):
 
 @cli.command()
 @click.argument("dirs", nargs=-1)
-@click.option("--all/--any", 'all_', default=True, help="results for keys present in ANY treants")
-@click.option("--json", '-j', 'json_', is_flag=True, help="results in JSON format")
+@click.option("--all/--any", 'all_', default=True,
+              help="results for keys present in ANY treants")
+@click.option("--json", '-j', 'json_', is_flag=True,
+              help="results in JSON format")
 @click.option("--get", cls=OptionEatAll, help="get values for keys")
 def categories(dirs, all_, json_, get):
     """Show treant categories"""
@@ -335,7 +344,7 @@ def add(dirs, tags, categories):
 @click.option("--tags", '-t', cls=OptionEatAll, help="list of tags")
 @click.option(
     "--categories",
-    '-c', 
+    '-c',
     cls=OptionEatAll,
     help="list of categories as key-value pairs separated by a colon ':'",
 )

--- a/src/datreant/metadata.py
+++ b/src/datreant/metadata.py
@@ -5,6 +5,7 @@ for filtering and selection.
 import os
 import itertools
 import functools
+import json
 from collections import defaultdict
 
 from fuzzywuzzy import process
@@ -57,19 +58,7 @@ class Tags(Metadata):
         return "<Tags({})>".format(self._list())
 
     def __str__(self):
-        tags = self._list()
-        agg = "Tags"
-        majsep = "="
-        seplength = len(agg)
-
-        if not tags:
-            out = "No Tags"
-        else:
-            out = agg + '\n'
-            out = out + majsep * seplength + '\n'
-            for i in range(len(tags)):
-                out = out + "'{}'\n".format(tags[i])
-        return out
+        return json.dumps(self._list(), indent=4)
 
     def __getitem__(self, value):
         # check if we might have a string to parse into a selection object
@@ -315,19 +304,7 @@ class Categories(Metadata):
         return "<Categories({})>".format(self._dict())
 
     def __str__(self):
-        categories = self._dict()
-        agg = "Categories"
-        majsep = "="
-        seplength = len(agg)
-
-        if not categories:
-            out = "No Categories"
-        else:
-            out = agg + '\n'
-            out = out + majsep * seplength + '\n'
-            for key in categories.keys():
-                out = out + "'{}': '{}'\n".format(key, categories[key])
-        return out
+        return json.dumps(self._dict(), indent=4)
 
     def __getitem__(self, keys):
         """Get values for given `keys`.

--- a/src/datreant/metadata.py
+++ b/src/datreant/metadata.py
@@ -519,19 +519,7 @@ class AggTags(AggMetadata):
         return "<AggTags({})>".format(list(self.all))
 
     def __str__(self):
-        tags = list(self.all)
-        agg = "Tags"
-        majsep = "="
-        seplength = len(agg)
-
-        if not tags:
-            out = "No Tags"
-        else:
-            out = agg + '\n'
-            out = out + majsep * seplength + '\n'
-            for i in xrange(len(tags)):
-                out = out + "'{}'\n".format(tags[i])
-        return out
+        return json.dumps(self.all, indent=4)
 
     def __iter__(self):
         return self.all.__iter__()
@@ -756,19 +744,7 @@ class AggCategories(AggMetadata):
         return "<AggCategories({})>".format(self.all)
 
     def __str__(self):
-        categories = self.all
-        agg = "Categories"
-        majsep = "="
-        seplength = len(agg)
-
-        if not categories:
-            out = "No Categories"
-        else:
-            out = agg + '\n'
-            out = out + majsep * seplength + '\n'
-            for key, value in categories.items():
-                out = out + "'{}': '{}'\n".format(key, value)
-        return out
+        return json.dumps(self.all, indent=4)
 
     def __getitem__(self, keys):
         """Get values for a given key, list of keys, or set of keys.

--- a/src/datreant/metadata.py
+++ b/src/datreant/metadata.py
@@ -634,7 +634,10 @@ class AggTags(AggMetadata):
 
         """
         tags = [set(member.tags) for member in self._collection]
-        out = set.union(*tags)
+        if tags:
+            out = set.union(*tags)
+        else:
+            out = set()
 
         return out
 
@@ -644,7 +647,10 @@ class AggTags(AggMetadata):
 
         """
         tags = [set(member.tags) for member in self._collection]
-        out = set.intersection(*tags)
+        if tags:
+            out = set.intersection(*tags)
+        else:
+            out = set()
 
         return out
 
@@ -876,6 +882,10 @@ class AggCategories(AggMetadata):
             All unique Categories among members.
         """
         keys = [set(member.categories.keys()) for member in self._collection]
+
+        if not keys:
+            return {}
+
         keys = set.union(*keys)
 
         return {k: [m.categories[k] if k in m.categories else None
@@ -892,6 +902,10 @@ class AggCategories(AggMetadata):
             Categories common to all members.
         """
         keys = [set(member.categories.keys()) for member in self._collection]
+
+        if not keys:
+            return {}
+
         keys = set.intersection(*keys)
 
         return {k: [m.categories[k] if k in m.categories else None
@@ -925,7 +939,7 @@ class AggCategories(AggMetadata):
             member.categories.add(categorydict, **categories)
 
     def remove(self, *categories):
-        """Remove categories from Treant.
+        """Remove categories from each Treant in collection.
 
         Any number of categories (keys) can be given as arguments, and these
         keys (with their values) will be deleted.
@@ -939,7 +953,7 @@ class AggCategories(AggMetadata):
             member.categories.remove(*categories)
 
     def clear(self):
-        """Remove all categories from all Treants in collection.
+        """Remove all categories from each Treant in collection.
 
         """
         for member in self._collection:

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -45,14 +45,32 @@ def test_init(in_tmpdir, tags, categories):
 
 @pytest.fixture
 def readymade_treant(in_tmpdir):
-    t = dtr.Treant('duchamp',
-                   tags='art?',
+    t = dtr.Treant('duchamp/fountain',
+                   tags=['art?', 'duchamp'],
                    categories={'colour': 'white',
                                'material': 'porcelain'},
     )
 
+@pytest.fixture
+def readymades(readymade_treant):
+    t2 = dtr.Treant('duchamp')
+    t3 = dtr.Treant('duchamp/wheel',
+                    tags=['duchamp'],
+                    categories={'material': 'wood'})
+    t4 = dtr.Treant('manray')
+    t5 = dtr.Treant('manray/gift',
+                    tags=['manray'],
+                    categories={'material': 'metal',
+                                'spiky': True})
+    t6 = dtr.Treant('hausmann')
+    t7 = dtr.Treant('hausmann/head',
+                    tags=['hausmann'],
+                    categories={'material': 'wood',
+                                'spiky': False})
+
+
 def test_show(readymade_treant):
-    ret = subprocess.run('dtr show duchamp', shell=True,
+    ret = subprocess.run('dtr show duchamp/fountain', shell=True,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True)
@@ -61,3 +79,33 @@ def test_show(readymade_treant):
     assert 'art?' in output
     assert 'colour' in output
     assert 'white' in output
+
+
+def test_discover(readymades):
+    ret = subprocess.run('dtr discover', shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+
+    output = ret.stdout.decode()
+
+    print(output)
+    items = [val for val in output.split('\n')
+             if val]  # ignore blank lines
+    assert len(items) == 7
+
+
+def test_get(readymades):
+    ret = subprocess.run('dtr get -c material:wood', shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+
+    # should return 2 results, 'duchamp/wheel' and 'hausmann/head'
+    output = ret.stdout.decode()
+    print('#' + output + '#')
+    assert len(output.split('\n')) == 2
+    assert 'wheel' in output
+    assert 'head' in output

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -49,7 +49,8 @@ def readymade_treant(in_tmpdir):
                    tags=['art?', 'duchamp'],
                    categories={'colour': 'white',
                                'material': 'porcelain'},
-    )
+                   )
+
 
 @pytest.fixture
 def readymades(readymade_treant):
@@ -88,7 +89,7 @@ def test_discover(readymades):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
 
     output = ret.stdout.decode()
 
@@ -104,7 +105,7 @@ def test_discover_cat(readymades):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
     # should return 2 results, 'duchamp/wheel' and 'hausmann/head'
     output = ret.stdout.decode()
     items = [item for item in output.split('\n')
@@ -121,7 +122,7 @@ def test_discover_tags(readymades):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
     # should return 2 results, both duchamps
     output = ret.stdout.decode()
     items = [item for item in output.split('\n')
@@ -138,7 +139,7 @@ def test_discover_both(readymades):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
     # should return 2 results, 'duchamp/wheel' and 'hausmann/head'
     output = ret.stdout.decode()
     items = [item for item in output.split('\n')
@@ -153,7 +154,7 @@ def test_get(readymades):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
 
     # should return 2 results, 'duchamp/wheel' and 'hausmann/head'
     output = ret.stdout.decode()
@@ -168,7 +169,7 @@ def test_tags(readymade_treant):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
 
     output = ret.stdout.decode()
 
@@ -181,7 +182,7 @@ def test_categories(readymade_treant):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
 
     output = ret.stdout.decode()
 
@@ -194,7 +195,7 @@ def test_add_tag(readymade_treant):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
 
     t = dtr.Treant('duchamp/fountain')
 
@@ -207,7 +208,7 @@ def test_add_category(readymade_treant):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
 
     t = dtr.Treant('duchamp/fountain')
 
@@ -220,7 +221,7 @@ def test_set_categories(readymades):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
-    )
+                         )
 
     for t in ['duchamp/wheel', 'duchamp/fountain']:
         treant = dtr.Treant(t)

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -41,3 +41,23 @@ def test_init(in_tmpdir, tags, categories):
         assert 'tasty' in t.tags
     if categories:
         assert t.categories['flavour'] == 'chicken'
+
+
+@pytest.fixture
+def readymade_treant(in_tmpdir):
+    t = dtr.Treant('duchamp',
+                   tags='art?',
+                   categories={'colour': 'white',
+                               'material': 'porcelain'},
+    )
+
+def test_show(readymade_treant):
+    ret = subprocess.run('dtr show duchamp', shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True)
+
+    output = ret.stdout.decode()
+    assert 'art?' in output
+    assert 'colour' in output
+    assert 'white' in output

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -150,7 +150,7 @@ def test_discover_both(readymades):
 
 
 def test_get(readymades):
-    ret = subprocess.run('dtr get -c material:wood', shell=True,
+    ret = subprocess.run('dtr get duchamp/* hausmann/* -c material:wood', shell=True,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,
@@ -158,8 +158,11 @@ def test_get(readymades):
 
     # should return 2 results, 'duchamp/wheel' and 'hausmann/head'
     output = ret.stdout.decode()
+    items = [item for item in output.split('\n')
+             if item]
+
     print('#' + output + '#')
-    assert len(output.split('\n')) == 2
+    assert len(items) == 2
     assert 'wheel' in output
     assert 'head' in output
 

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -96,6 +96,56 @@ def test_discover(readymades):
     assert len(items) == 7
 
 
+def test_discover_cat(readymades):
+    ret = subprocess.run('dtr discover -c material:wood',
+                         shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+    # should return 2 results, 'duchamp/wheel' and 'hausmann/head'
+    output = ret.stdout.decode()
+    items = [item for item in output.split('\n')
+             if item]
+
+    assert len(items) == 2
+    assert 'duchamp/wheel/' in items
+    assert 'hausmann/head/' in items
+
+
+def test_discover_tags(readymades):
+    ret = subprocess.run('dtr discover -t duchamp',
+                         shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+    # should return 2 results, both duchamps
+    output = ret.stdout.decode()
+    items = [item for item in output.split('\n')
+             if item]
+
+    assert len(items) == 2
+    assert 'duchamp/fountain/' in items
+    assert 'duchamp/wheel/' in items
+
+
+def test_discover_both(readymades):
+    ret = subprocess.run('dtr discover -t duchamp -c colour:white',
+                         shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+    # should return 2 results, 'duchamp/wheel' and 'hausmann/head'
+    output = ret.stdout.decode()
+    items = [item for item in output.split('\n')
+             if item]
+
+    assert len(items) == 1
+    assert 'duchamp/fountain/' in items
+
+
 def test_get(readymades):
     ret = subprocess.run('dtr get -c material:wood', shell=True,
                          stdout=subprocess.PIPE,

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -150,7 +150,8 @@ def test_discover_both(readymades):
 
 
 def test_get(readymades):
-    ret = subprocess.run('dtr get duchamp/* hausmann/* -c material:wood', shell=True,
+    ret = subprocess.run('dtr get duchamp/* hausmann/* -c material:wood',
+                         shell=True,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          check=True,

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -109,3 +109,54 @@ def test_get(readymades):
     assert len(output.split('\n')) == 2
     assert 'wheel' in output
     assert 'head' in output
+
+
+def test_tags(readymade_treant):
+    ret = subprocess.run('dtr tags duchamp/fountain', shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+
+    output = ret.stdout.decode()
+
+    assert 'art?' in output
+    assert 'duchamp' in output
+
+
+def test_categories(readymade_treant):
+    ret = subprocess.run('dtr categories duchamp/fountain', shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+
+    output = ret.stdout.decode()
+
+    assert 'colour : white' in output
+
+
+def test_add_tag(readymade_treant):
+    ret = subprocess.run('dtr add duchamp/fountain -t dada',
+                         shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+
+    t = dtr.Treant('duchamp/fountain')
+
+    assert 'dada' in t.tags
+
+
+def test_add_category(readymade_treant):
+    ret = subprocess.run('dtr add duchamp/fountain -c year:1917',
+                         shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+
+    t = dtr.Treant('duchamp/fountain')
+
+    assert t.categories['year'] == 1917

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -65,8 +65,10 @@ def readymades(readymade_treant):
     t6 = dtr.Treant('hausmann')
     t7 = dtr.Treant('hausmann/head',
                     tags=['hausmann'],
-                    categories={'material': 'wood',
-                                'spiky': False})
+                    categories={
+                        'origin': 'austria',
+                        'material': 'wood',
+                        'spiky': False})
 
 
 def test_show(readymade_treant):
@@ -210,3 +212,18 @@ def test_add_category(readymade_treant):
     t = dtr.Treant('duchamp/fountain')
 
     assert t.categories['year'] == 1917
+
+
+def test_set_categories(readymades):
+    ret = subprocess.run('dtr set duchamp/* -c origin:france',
+                         shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         check=True,
+    )
+
+    for t in ['duchamp/wheel', 'duchamp/fountain']:
+        treant = dtr.Treant(t)
+
+        assert treant.categories['origin'] == 'france'
+    assert not dtr.Treant('hausmann/head').categories['origin'] == 'france'

--- a/src/datreant/tests/test_cli.py
+++ b/src/datreant/tests/test_cli.py
@@ -1,0 +1,43 @@
+"""Tests for the chicken licking interface
+
+"""
+
+import subprocess
+import pathlib
+import pytest
+
+import datreant as dtr
+
+
+@pytest.fixture()
+def in_tmpdir(tmpdir):
+    with tmpdir.as_cwd():
+        yield
+
+
+@pytest.mark.parametrize('tags', [False, True])
+@pytest.mark.parametrize('categories', [False, True])
+def test_init(in_tmpdir, tags, categories):
+    cmd = 'dtr init thisdir'
+    if tags:
+        cmd += ' -t tasty'
+    if categories:
+        cmd += ' -c flavour:chicken'
+
+    subprocess.run(cmd,
+                   shell=True,
+                   stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                   check=True)
+
+    loc = pathlib.Path('./thisdir')
+    assert loc.exists
+    # Check that treant exists before opening
+    dtrloc = (loc / '.datreant')
+    assert dtrloc.exists
+
+    t = dtr.Treant('thisdir')
+
+    if tags:
+        assert 'tasty' in t.tags
+    if categories:
+        assert t.categories['flavour'] == 'chicken'

--- a/src/datreant/tests/test_treants.py
+++ b/src/datreant/tests/test_treants.py
@@ -353,11 +353,6 @@ class TestTreant(TestTree):
             with pytest.raises(ValueError):
                 treant.tags.add(tag)
 
-        def test_tags_printing(self, treant):
-            treant.tags.add('marklar')
-            repr = str(treant.tags)
-            assert repr == "Tags\n====\n'marklar'\n"
-
     class TestCategories:
         """Test treant categories"""
 


### PR DESCRIPTION
I've placed `datreant.cli` (thanks @kain88-de for pioneering this!) into `datreant` proper, and went buck wild with it. The general pattern here is as follows:

```
dtr
  --version
  --help

  init <dirs> --categories a:b c:d --tags x y z
  show <dirs>
  draw <dirs>
  discover <dirs> --json --relpath/--abspath --categories a:b c:d --tags x y z
  get <dirs> --json --relpath/--abspath --categories a:b c:d --tags x y z

  tags <dirs> --all/--any --json --has x y z
  categories <dirs> --all/--any --json --get a c

  add <dirs> --categories a:b c:d --tags x y z
  set <dirs> --categories a:b c:d --tags x y z
  del <dirs> --categories a c --tags x y z    
  clear <dirs>  --categories --tags
  help

All subcommands can take <dirs> from STDIN by giving '-' for <dirs>. If no
<dirs> given, '.' is used.

All subcommands operate from the perspective of a `Bundle`. This means that even
when operating on a single Treant, they produce results in the same form as if
they were operating on multiples. This thinking typically matters only for
`--json` outputs.

Each command will have a verbose flag; debug output sent to `STDERR`.
```

Needs:
- [ ] verbose flag (`--verbose`, `-v`) for each subcommand giving debug output
- [ ] tests
- [ ] a doc page