### PR TITLE
Tidying of running tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,4 @@ exclude_lines =
     if __name__ == .__main__.:
 
 omit =
-    src/datreant/core/tests/*
-    src/datreant/__init__.py
+    src/datreant/tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 cache: pip
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ branches:
 # install python dependencies
 install:
   - pip install codecov
-  - pip install mock
   - pip install --upgrade pytest
   - pip install pytest-cov
   - pip install pytest-pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 
 # run tests
 script: 
-  - py.test --cov src/datreant --pep8 src/datreant -v --doctest-modules
+  - pytest -v --doctest-modules
   # test conversion script runs
   - datreant_07to1 --help
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-sudo: required
-dist: xenial
+cache: pip
 
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 
 # run tests
 script: 
-  - pytest -v --doctest-modules
+  - pytest -v
   # test conversion script runs
   - datreant_07to1 --help
 

--- a/conda/datreant.core/run_test.py
+++ b/conda/datreant.core/run_test.py
@@ -2,4 +2,4 @@ import pytest
 import os
 import datreant.core as dtr
 
-pytest.main(os.path.dirname(dtr.__file__))
+pytest.main([os.path.dirname(dtr.__file__)])

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,10 @@ pep8ignore =
     __init__.py E402
     selectionparser.py E501
     test_parser.py E501
+    docs/* ALL
+    conda/* ALL
+    setup.py ALL
+addopts = --cov --pep8
 
 [bdist_wheel]
 universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ pep8ignore =
     docs/* ALL
     conda/* ALL
     setup.py ALL
-addopts = --cov --pep8
+addopts = --cov --pep8 --doctest-modules src/datreant
 
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
                   ['datreant_07to1=datreant.scripts.datreant_07to1:main']},
     license='BSD',
     long_description=open('README.rst').read(),
-    tests_require=['numpy', 'pytest>=2.10', 'mock'],
+    tests_require=['numpy', 'pytest>=2.10'],
     install_requires=[
         'asciitree', 'scandir', 'fuzzywuzzy',
         'python-Levenshtein', 'pyparsing'])

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
                   ['datreant_07to1=datreant.scripts.datreant_07to1:main']},
     license='BSD',
     long_description=open('README.rst').read(),
-    tests_require=['numpy', 'pytest>=2.10'],
+    tests_require=['numpy', 'pytest>=2.10', 'pytest-cov', 'pytest-pep8'],
     install_requires=[
         'asciitree', 'scandir', 'fuzzywuzzy',
         'python-Levenshtein', 'pyparsing'])

--- a/src/datreant/tests/test_treants.py
+++ b/src/datreant/tests/test_treants.py
@@ -5,7 +5,7 @@
 import datreant as dtr
 from datreant import Treant
 import pytest
-import mock
+from unittest import mock
 import os
 import py
 import errno

--- a/src/datreant/tests/test_util.py
+++ b/src/datreant/tests/test_util.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import errno


### PR DESCRIPTION
mock is standard library from py3.3, simplifies things

I think some bitrot, but running pytest from root of repo didn't work

also made running from repo root more like what runs on travis (to prevent surprises)