### PR TITLE
Fix for #175

### DIFF
--- a/src/datreant/metadata.py
+++ b/src/datreant/metadata.py
@@ -95,8 +95,9 @@ class Tags(Metadata):
                 fits = value in self
             else:
                 raise ValueError(
-                        "Given value is not a valid selection. "
-                        "See documentation for tags selection options")
+                        f"Given value ({repr(value)}) of type {type(value)} "
+                        "is not a valid selection. See documentation for "
+                        "tags selection options")
 
             return fits
 

--- a/src/datreant/metadata.py
+++ b/src/datreant/metadata.py
@@ -87,12 +87,16 @@ class Tags(Metadata):
             elif isinstance(value, tuple):
                 # a tuple of tags gives members with ANY of the tags
                 fits = any(self._getselection(item) for item in value)
-            if isinstance(value, set):
+            elif isinstance(value, set):
                 # a set of tags gives only members WITHOUT ALL the tags
                 # can be used for `not`, basically
                 fits = not all(self._getselection(item) for item in value)
             elif isinstance(value, str):
                 fits = value in self
+            else:
+                raise ValueError(
+                        "Given value is not a valid selection. "
+                        "See documentation for tags selection options")
 
             return fits
 

--- a/src/datreant/tests/test_treants.py
+++ b/src/datreant/tests/test_treants.py
@@ -348,6 +348,10 @@ class TestTreant(TestTree):
             # complex logic
             assert t.tags[[('marklar', 'bark'), {'dark'}]]
 
+            # error on forbidden types
+            with pytest.raises(ValueError) as e:
+                t.tags[1]
+
         @pytest.mark.parametrize('tag', (1, 1.2))
         def test_tags_only_strings(self, treant, tag):
             with pytest.raises(ValueError):


### PR DESCRIPTION
Now raise appropriate error when an unrecognizable tag selection is made; also fixes an `if` that should have been an `elif`. Thanks to @kaceyreidy for finding this issue!